### PR TITLE
Fix serialization issue of SRS that causes unnatural high mem consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ repository.
 * A working Rust installation.
 
 ## Hardware requirements
-We recommend using a machine with at least 8GB of RAM.
+A machine with at least 8GB of RAM is required.
 
 ## Build the CLI
 

--- a/src/ceremony.rs
+++ b/src/ceremony.rs
@@ -109,14 +109,15 @@ impl SRS {
     pub fn write_to_file(&self, path: &Path) {
         let mut file = create_file(path);
 
-        let mut bytes;
         for g1_point in &self.g1s {
-            bytes = g1_point.to_raw_bytes();
-            file.write_all(&bytes).expect("Cannot write to file");
+            file.write_all(&g1_point.to_raw_bytes())
+                .expect("Cannot write to file");
         }
 
-        let g2_points: Vec<u8> = self.g2s.par_iter().flat_map(|p| p.to_raw_bytes()).collect();
-        file.write_all(&g2_points).expect("Cannot write to file");
+        file.write_all(&self.g2s[0].to_raw_bytes())
+            .expect("Cannot write to file");
+        file.write_all(&self.g2s[1].to_raw_bytes())
+            .expect("Cannot write to file");
     }
 
     pub fn read_from_file(path: &Path) -> Self {


### PR DESCRIPTION
Summary:
* Remove rayon's par_iter from serializing SRS and replace it by a simple streaming version that writes each point individually to the filesystem; this resolves the high mem consumption caused by par_iter

Other minor changes:
* Import rayon functionality as per the recommendations of the rayon crate
* Add hardware requirements to README