### PR TITLE
Add sanity checks for SRS length and non-trivial updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ put <PATH-TO-UPDATED-SRS> .
 
 ## Optional: Verify the latest SRS
 
-The latest SRS can be found at [LatestSRS], its exact size is `3221225856 B`.
-Once you’ve downloaded the latest SRS, you can confirm its authenticity
-by comparing its SHA-256 checksum with the one listed in PARTICIPANTS.md:
+The latest SRS can be found at [LatestSRS], its exact size is `3221225856 B`
+(about `3.2 GB`). Once you have downloaded the latest SRS, you can confirm its
+authenticity by comparing its SHA-256 checksum with the one listed in
+PARTICIPANTS.md:
 ```sh
 sha256sum <PATH-TO-DOWNLOADED-SRS>
 ```

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ This is the official repository for the trusted-setup ceremony of the
 [Midnight Network](https://midnight.network/).
 
 The outcome of this ceremony will be a so-called *powers-of-tau* structured
-reference string (SRS) over the BLS12-381 elliptic curve.
+reference string (SRS) over the BLS12-381 elliptic curve of length $2^{25}$
+(see our [wiki](WIKI.md) for more details on the type and length of the SRS).
 
 The ceremony is based on the
 [Filecoin ceremony](https://trusted-setup.filecoin.io/phase1/), an existing
 powers-of-tau SRS over BLS12-381 used on [Filecoin](https://filecoin.io/)
 and trusted by the Web3 community.
 
-During the Midnight Network's ceremony, the Filecoin SRS will be re-randomized 
-(or updated) multiple times by various participants. Each update generates not 
-only a new SRS but also an update proof, which proves that the previous 
-SRS was used correctly in the update process. The chain of update proofs will 
-be stored in the `proofs/` directory of this
-repository.
+During Midnight Network's ceremony, the Filecoin SRS will be updated 
+(i.e., re-randomized) multiple times by various participants. Each update
+generates not  only a new SRS but also an update proof, which proves that
+the previous SRS was used correctly in the update process. The chain of
+update proofs will be stored in the `proofs/` directory of this repository.
 
 > [!IMPORTANT]
 > This ceremony is currently ongoing and you can be a participant!
@@ -89,16 +89,16 @@ put <PATH-TO-UPDATED-SRS> .
 
 ## Optional: Verify the latest SRS
 
-The latest SRS can be found at [LatestSRS], its size is `3.1GB`. Once you’ve
+The latest SRS can be found at [LatestSRS], its size is approx. `3.1GB`. Once you’ve
 downloaded the latest SRS, you can confirm its authenticity by comparing its
 SHA-256 checksum with the one listed in PARTICIPANTS.md:
 ```sh
 sha256sum <PATH-TO-DOWNLOADED-SRS>
 ```
 
-Next, you may verify that it is structurally correct with:
+Next, you may verify that it is structurally correct and has the expected length of $2^{25}$ with:
 ```sh
-./srs_utils <PATH-TO-DOWNLOADED-SRS> verify-structure
+./srs_utils <PATH-TO-DOWNLOADED-SRS> verify-structure -l 25
 ```
 
 You can also verify the chain of update proofs that link the latest SRS to

--- a/README.md
+++ b/README.md
@@ -89,14 +89,15 @@ put <PATH-TO-UPDATED-SRS> .
 
 ## Optional: Verify the latest SRS
 
-The latest SRS can be found at [LatestSRS], its size is approx. `3.1GB`. Once you’ve
-downloaded the latest SRS, you can confirm its authenticity by comparing its
-SHA-256 checksum with the one listed in PARTICIPANTS.md:
+The latest SRS can be found at [LatestSRS], its exact size is `3221225856 B`.
+Once you’ve downloaded the latest SRS, you can confirm its authenticity
+by comparing its SHA-256 checksum with the one listed in PARTICIPANTS.md:
 ```sh
 sha256sum <PATH-TO-DOWNLOADED-SRS>
 ```
 
-Next, you may verify that it is structurally correct and has the expected length of $2^{25}$ with:
+Next, you may verify that it is structurally correct and has the expected
+length of $2^{25}$ with:
 ```sh
 ./srs_utils <PATH-TO-DOWNLOADED-SRS> verify-structure -l 25
 ```

--- a/WIKI.md
+++ b/WIKI.md
@@ -4,7 +4,9 @@ Welcome to the wiki of [Midnight](https://midnight.network/)'s trusted-setup
 ceremony.
 
 The outcome of this ceremony will be a so-called *powers-of-tau* structured
-reference string (SRS) over the BLS12-381 elliptic curve.
+reference string (SRS) over the BLS12-381 elliptic curve of length $2^{25}$
+for the [KZG](https://www.iacr.org/archive/asiacrypt2010/6477178/6477178.pdf)
+polynomial commitment scheme.
 
 We build upon the last output file `challenge19` of Filecoin's 
 `perpetualpowersoftau` ceremony (for the Groth16 proving system) over BLS12-381
@@ -12,7 +14,7 @@ described [here](https://github.com/arielgabizon/perpetualpowersoftau). The
 `challenge19` file is hosted 
 [via IPFS](https://trusted-setup.filecoin.io/phase1/).
 
-An SRS for Groth16 naturally contains the relevant points of an SRS for a
+An SRS for Groth16 naturally contains the relevant points of an SRS for
 KZG-based PLONK. In particular, we aim for a KZG SRS size of $2^{25}$.
 For this purpose, we extracted:
 
@@ -87,7 +89,7 @@ first $\mathbb{G}_1$ point $[\tau]_1$ from Filecoin's SRS in the file
 Participants and verifiers are encouraged to extract this point themselves.
 Our script provides functionality for that:
 
-0. If you have not already, build and copy the binary with
+0. If you haven't already, build and copy the binary with
    ```sh
    cargo build --release 
    cp ./target/release/srs_utils ./

--- a/WIKI.md
+++ b/WIKI.md
@@ -89,7 +89,7 @@ first $\mathbb{G}_1$ point $[\tau]_1$ from Filecoin's SRS in the file
 Participants and verifiers are encouraged to extract this point themselves.
 Our script provides functionality for that:
 
-0. If you haven't already, build and copy the binary with
+0. If you have not already, build and copy the binary with
    ```sh
    cargo build --release 
    cp ./target/release/srs_utils ./

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,19 +41,16 @@ struct CLICommand {
     srs_path: String,
 }
 
-#[derive(Subcommand, Debug, Clone)]
+#[derive(Subcommand, Debug)]
 enum Command {
-    VerifyStructure(VerifyStructureArgs),
+    VerifyStructure {
+        /// Asserting 2**log2_len G1 elements in the SRS (incl. the generator)
+        #[arg(short, long)]
+        log2_len: usize,
+    },
     VerifyChain,
     Update,
     ExtractFilecoinG1Point,
-}
-
-#[derive(Parser, Debug, Clone)]
-struct VerifyStructureArgs {
-    /// Asserting 2**length G1 elements in the SRS (incl. the generator)
-    #[arg(short, long)]
-    length: usize,
 }
 
 fn verify_chain(last_srs_path: &Path) {
@@ -150,8 +147,8 @@ fn main() {
     let args = CLICommand::parse();
 
     match args.cmd {
-        Command::VerifyStructure(sub_args) => {
-            verify_structure(Path::new(&args.srs_path), sub_args.length)
+        Command::VerifyStructure { log2_len } => {
+            verify_structure(Path::new(&args.srs_path), log2_len)
         }
         Command::VerifyChain => verify_chain(Path::new(&args.srs_path)),
         Command::Update => update(Path::new(&args.srs_path)),


### PR DESCRIPTION
Changes
----------------------
* Check the expected size of the SRS via the `verify-structure` command of the SRS tool (instead of having to manually check the expected byte length of the SRS file)
* Check for non-trivial updates in the `verify-chain` command (instead of having to manually compare SRS hashes)
* Update README and WIKI