### PR TITLE
Minor fix in documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -12,7 +12,7 @@ Examples of behavior that contributes to creating a positive environment include
 
 Examples of unacceptable behavior by participants include:
 
--The use of sexualized language or imagery and unwelcome sexual attention or advances
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
 - Trolling, insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
 - Publishing others’ private information, such as a physical or electronic address, without explicit permission

--- a/MIDNIGHT_SRS_CATALOG.md
+++ b/MIDNIGHT_SRS_CATALOG.md
@@ -4,7 +4,7 @@ This document lists the available extended SRS files containing both
 coefficient and Lagrange representations for various sizes.
 
 Each extended SRS file includes:
-- `4` bytes representing the length `n` (in little-endian),
+- `4` bytes representing the size `k` (in little-endian),
 - `n` G1 points in coefficient (monomial) basis: `[1, τ, τ², ..., τⁿ⁻¹]₁`,
 - `n` G1 points in Lagrange basis: `[L₀(τ), L₁(τ), ..., Lₙ₋₁(τ)]₁`,
 - `2` G2 points: `[1, τ]₂`.

--- a/MIDNIGHT_SRS_CATALOG.md
+++ b/MIDNIGHT_SRS_CATALOG.md
@@ -5,7 +5,7 @@ coefficient and Lagrange representations for various sizes.
 
 Each extended SRS file includes:
 - `4` bytes representing the size `k` (in little-endian),
-- `n` G1 points in coefficient (monomial) basis: `[1, τ, τ², ..., τⁿ⁻¹]₁`,
+- `n` G1 points in coefficient (monomial) basis: `[1, τ, τ², ..., τⁿ⁻¹]₁`, where `n = 2^k`,
 - `n` G1 points in Lagrange basis: `[L₀(τ), L₁(τ), ..., Lₙ₋₁(τ)]₁`,
 - `2` G2 points: `[1, τ]₂`.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Note that Drand round `N = 5686659` was sampled on Dec 18, 2025 at around
 
 ### How we seeded the last iteration
 
-The following steps for seeding the last iteration (with the Dround entropy)
+The following steps for seeding the last iteration (with the Drand entropy)
 were designed and
 [declared](https://github.com/midnightntwrk/midnight-trusted-setup/commit/c1e700b299167db84e0b14c652a3bf8e8646b258)
 a week before the `5686659`-th Drand round was sampled.
@@ -231,7 +231,7 @@ This command will:
 2. Fetch the data associated to the `5686659`-th Drand round and validate
    its signature.
 3. Derive the scalar `tau` used in the last iteration, as detailed
-   [above](#how-we-seed-the-last-iteration).
+   [above](#how-we-seeded-the-last-iteration).
 4. Make sure that the last contribution (proved in file
    [`./proofs/proof38`](https://github.com/midnightntwrk/midnight-trusted-setup/blob/main/proofs/proof38))
    was performed with such `tau`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ will send a more detailed response within an additional three (3) business days
 indicating the next steps in handling your report.
 
 If you've been unable to successfully draft a vulnerability report via GitHub
-or have not received a response during the alloted response window, please
+or have not received a response during the allotted response window, please
 reach out via the [Midnight foundation security contact email](mailto:security@midnight.foundation).
 
 After the initial reply to your report, the maintainers will endeavor to keep

--- a/WIKI.md
+++ b/WIKI.md
@@ -38,7 +38,7 @@ SRS files.
 
 ### Downloading the latest SRS
 
-There a public link to the
+There is a public link to the
 [latest SRS](https://srs.midnight.network/midnight-powers-of-tau-2p25) at each 
 stage of the ceremony. After the ceremony is completed, the same link
 will reference the final SRS for long-term retrieval.


### PR DESCRIPTION
The first 4 bytes of every file in our `MIDNIGHT_SRS_CATALOG` represents the SRS size `k`, not the actual length `n = 2^k`.